### PR TITLE
riscv: Fix S/MTVEC calculation for exception and interrupt.

### DIFF
--- a/arch/riscv/helper.c
+++ b/arch/riscv/helper.c
@@ -408,9 +408,9 @@ void do_interrupt(CPUState *env)
 
         /* Lowest bit of MTVEC changes mode to vectored interrupt */
         if ((env->mtvec & 1) && is_interrupt && env->privilege_architecture >= RISCV_PRIV1_10) {
-            env->pc = (env->mtvec & ~0x1) + (fixed_cause * 4);
+            env->pc = (env->mtvec & ~0x3) + (fixed_cause * 4);
         } else {
-            env->pc = env->mtvec;
+            env->pc = env->mtvec & ~0x3;
         }
 
         target_ulong ms = env->mstatus;
@@ -432,9 +432,9 @@ void do_interrupt(CPUState *env)
 
         /* Lowest bit of STVEC changes mode to vectored interrupt */
         if ((env->stvec & 1) && is_interrupt && (env->privilege_architecture >= RISCV_PRIV1_10)) {
-            env->pc = (env->stvec & ~0x1) + (fixed_cause * 4);
+            env->pc = (env->stvec & ~0x3) + (fixed_cause * 4);
         } else {
-            env->pc = env->stvec;
+            env->pc = env->stvec & ~0x3;
         }
 
         target_ulong s = env->mstatus;


### PR DESCRIPTION
* Lowest 2-bits of MTVEC are used for interrupt mode only.
* According to 3.1.7 (mtvec) of the privileged spec bits mtvec[1:0] are used for MODE
* This is an issue for something like the IBEX where it only supports vector interrupt mode and mtvec[0:1] = 0x1 is RO
* See https://ibex-core.readthedocs.io/en/latest/03_reference/cs_registers.html#machine-trap-vector-base-address-mtvec