### PR TITLE
RISC-V: Add vector registers

### DIFF
--- a/arch/riscv/cpu.h
+++ b/arch/riscv/cpu.h
@@ -65,6 +65,8 @@ typedef struct CPUState CPUState;
 struct CPUState {
     target_ulong gpr[32];
     uint64_t fpr[32]; /* assume both F and D extensions */
+    uint8_t vr[2048];
+
     target_ulong pc;
 
     target_ulong frm;


### PR DESCRIPTION
Adds vector registers to riscv arch, similar to how arm neon vfp
registers are added as a member of the CPUState struct.

Adding the vector registers as a single byte array makes it simple to
implement the many LMUL/SEW settings for each vector instruction.

The base address within vr array of a register is readily calculated by
multiplying the integer by env->vlenb.

The number of bytes in the array will also need to be set by vlenb,
which is archicture dependent, but hoping this might serve as a
reasonable placeholder for vector development.