### PR TITLE
Add fix for gen_v simm5 extraction

### DIFF
--- a/arch/riscv/translate.c
+++ b/arch/riscv/translate.c
@@ -2359,6 +2359,7 @@ static void gen_v(DisasContext *dc, uint32_t opc, int rd, int rs1, int rs2, int 
     }
     uint8_t funct6 = extract32(dc->opcode, 26, 6);
     uint8_t vm = extract32(dc->opcode, 25, 1);
+    int64_t simm5;
 
     switch (opc) {
     case OPC_RISC_V_IVV:
@@ -2371,7 +2372,7 @@ static void gen_v(DisasContext *dc, uint32_t opc, int rd, int rs1, int rs2, int 
         gen_v_opmvv(dc, funct6, rd, rs1, rs2, vm);
         break;
     case OPC_RISC_V_IVI:
-        int64_t simm5 = rs1 >= 0x10 ? (0xffffffffffffffe0) | rs1 : rs1;
+        simm5 = rs1 >= 0x10 ? (0xffffffffffffffe0) | rs1 : rs1;
         gen_v_opivi(dc, funct6, rd, simm5, rs2, vm);
         break;
     case OPC_RISC_V_IVX:


### PR DESCRIPTION
Compilation of Renode yielded the following error for this section of gen_v:

tlib/arch/riscv/translate.c:1899:13: error: a label can only be part
of a statement and a declaration is not a statement
This change just separates the declaration and the initializatoin into
separate lines, which then allows for compilation to proceed
without errors.