### PR TITLE
RiscV: Add vsetivli instructions for v-ext

### DIFF
--- a/arch/riscv/helper.h
+++ b/arch/riscv/helper.h
@@ -83,7 +83,7 @@ DEF_HELPER_2(reserve_address, void, env, tl)
 DEF_HELPER_2(check_address_reservation, tl, env, tl)
 
 /* Vector Extension */
-DEF_HELPER_5(vsetvl, tl, env, tl, tl, tl, tl)
+DEF_HELPER_6(vsetvl, tl, env, tl, tl, tl, tl, i32)
 
 DEF_HELPER_5(vle8, void, env, i32, i32, i32, i32)
 DEF_HELPER_5(vle8ff, void, env, i32, i32, i32, i32)

--- a/arch/riscv/instmap.h
+++ b/arch/riscv/instmap.h
@@ -503,10 +503,12 @@ enum {
     RISC_V_FUNCT_FWNMSAC     = 0b111111, //                                    OPFVV, OPFVF
 };
 
-#define MASK_OP_V_CFG(op) (MASK_OP_MAJOR(op) | OPC_RISC_V_CFG | (op & (0x1 << 31)))
+#define MASK_OP_V_CFG(op) (op & OPC_RISC_V_CFG) | (op & (0x3 << 30))
 enum {
-    OPC_RISC_VSETVLI   = OPC_RISC_V | OPC_RISC_V_CFG | (0x0 << 31),
-    OPC_RISC_VSETVL    = OPC_RISC_V | OPC_RISC_V_CFG | (0x1 << 31),
+    OPC_RISC_VSETVLI_0   = OPC_RISC_V_CFG | (0x0 << 30),
+    OPC_RISC_VSETVLI_1   = OPC_RISC_V_CFG | (0x1 << 30),
+    OPC_RISC_VSETVL      = OPC_RISC_V_CFG | (0x2 << 30),
+    OPC_RISC_VSETIVLI    = OPC_RISC_V_CFG | (0x3 << 30),
 };
 
 #define GET_B_IMM(inst)          ((extract32(inst, 8, 4) << 1)\

--- a/arch/riscv/translate.c
+++ b/arch/riscv/translate.c
@@ -1824,14 +1824,28 @@ static void gen_v_cfg(DisasContext *dc, uint32_t opc, int rd, int rs1, int rs2, 
     tcg_gen_movi_tl(imm_rs1, rs1);
     tcg_gen_movi_tl(csr_store, CSR_VL);
 
+    if (opc == OPC_RISC_VSETIVLI){
+        tcg_gen_movi_i32(vec_imm, 1);
+    } else {
+        tcg_gen_movi_i32(vec_imm, 0);
+    }
+
     switch (opc) {
         case OPC_RISC_VSETVL:
-            // set VL csr
-            gen_helper_vsetvl(dest, cpu_env, rd_pass, imm_rs1, source1, source2);
+            gen_helper_vsetvl(dest, cpu_env, rd_pass, imm_rs1, source1, source2,
+                              vec_imm);
             break;
-        case OPC_RISC_VSETVLI:
-            // set VL
-            gen_helper_vsetvl(dest, cpu_env, rd_pass, imm_rs1, source1, rs2_pass);
+        case OPC_RISC_VSETVLI_0:
+            gen_helper_vsetvl(dest, cpu_env, rd_pass, imm_rs1, source1, rs2_pass,
+                              vec_imm);
+            break;
+        case OPC_RISC_VSETVLI_1:
+            gen_helper_vsetvl(dest, cpu_env, rd_pass, imm_rs1, source1, rs2_pass,
+                              vec_imm);
+            break;
+        case OPC_RISC_VSETIVLI:
+            gen_helper_vsetvl(dest, cpu_env, rd_pass, imm_rs1, rs1_pass, rs2_pass,
+                              vec_imm);
             break;
         default:
             kill_unknown(dc, RISCV_EXCP_ILLEGAL_INST);
@@ -2172,7 +2186,7 @@ static void gen_v_opivi(DisasContext *dc, uint8_t funct6, int vd, int rs1, int v
     int64_t simm5 = rs1;
     TCGv t_simm5;
     t_simm5 = tcg_temp_new_i64();
-    
+
     switch (funct6) {
     // Common for vi and vx
     // zero-extended immediate

--- a/include/def-helper.h
+++ b/include/def-helper.h
@@ -119,6 +119,8 @@
     DEF_HELPER_FLAGS_4(name, 0, ret, t1, t2, t3, t4)
 #define DEF_HELPER_5(name, ret, t1, t2, t3, t4, t5) \
     DEF_HELPER_FLAGS_5(name, 0, ret, t1, t2, t3, t4, t5)
+#define DEF_HELPER_6(name, ret, t1, t2, t3, t4, t5, t6) \
+    DEF_HELPER_FLAGS_6(name, 0, ret, t1, t2, t3, t4, t5, t6)
 
 #endif /* DEF_HELPER_H */
 
@@ -145,6 +147,9 @@ dh_ctype(ret) HELPER(name) (dh_ctype(t1), dh_ctype(t2), dh_ctype(t3), \
 dh_ctype(ret) HELPER(name) (dh_ctype(t1), dh_ctype(t2), dh_ctype(t3), \
                             dh_ctype(t4), dh_ctype(t5));
 
+#define DEF_HELPER_FLAGS_6(name, flags, ret, t1, t2, t3, t4, t5, t6) \
+dh_ctype(ret) HELPER(name) (dh_ctype(t1), dh_ctype(t2), dh_ctype(t3), \
+                            dh_ctype(t4), dh_ctype(t5), dh_ctype(t6));
 #undef GEN_HELPER
 #define GEN_HELPER -1
 
@@ -222,6 +227,23 @@ static inline void glue(gen_helper_, name)(dh_retvar_decl(ret) dh_arg_decl(t1, 1
   dh_arg(t5, 5); \
   tcg_gen_helperN(HELPER(name), flags, sizemask, dh_retvar(ret), 5, args); \
 }
+
+#define DEF_HELPER_FLAGS_6(name, flags, ret, t1, t2, t3, t4, t5, t6) \
+static inline void glue(gen_helper_, name)(dh_retvar_decl(ret) dh_arg_decl(t1, 1), \
+    dh_arg_decl(t2, 2), dh_arg_decl(t3, 3), dh_arg_decl(t4, 4), dh_arg_decl(t5, 5), \
+    dh_arg_decl(t6, 6)) \
+{ \
+  TCGArg args[6]; \
+  int sizemask = 0; \
+  dh_sizemask(ret, 0); \
+  dh_arg(t1, 1); \
+  dh_arg(t2, 2); \
+  dh_arg(t3, 3); \
+  dh_arg(t4, 4); \
+  dh_arg(t5, 5); \
+  dh_arg(t6, 6); \
+  tcg_gen_helperN(HELPER(name), flags, sizemask, dh_retvar(ret), 6, args); \
+}
 #undef GEN_HELPER
 #define GEN_HELPER -1
 
@@ -246,6 +268,9 @@ DEF_HELPER_FLAGS_0(name, flags, ret)
 #define DEF_HELPER_FLAGS_5(name, flags, ret, t1, t2, t3, t4, t5) \
 DEF_HELPER_FLAGS_0(name, flags, ret)
 
+#define DEF_HELPER_FLAGS_6(name, flags, ret, t1, t2, t3, t4, t5, t6) \
+DEF_HELPER_FLAGS_0(name, flags, ret)
+
 #undef GEN_HELPER
 #define GEN_HELPER -1
 
@@ -258,6 +283,7 @@ DEF_HELPER_FLAGS_0(name, flags, ret)
 #undef DEF_HELPER_FLAGS_3
 #undef DEF_HELPER_FLAGS_4
 #undef DEF_HELPER_FLAGS_5
+#undef DEF_HELPER_FLAGS_6
 #undef GEN_HELPER
 
 #endif


### PR DESCRIPTION
Add vsetivli instructions as they are used in clang generated code frequently.