### PR TITLE
exports: fix tlib_clear_page_io_accessed address removal

### DIFF
--- a/exports.c
+++ b/exports.c
@@ -766,10 +766,11 @@ void tlib_clear_page_io_accessed(uint64_t address)
         return;
     }
 
-    for(j = env->io_access_regions_count - 1; j > i; j--)
+    for(j = i; j < env->io_access_regions_count - 1; j++)
     {
-        env->io_access_regions[j - 1] = env->io_access_regions[j];
+        env->io_access_regions[j] = env->io_access_regions[j + 1];
     }
+    env->io_access_regions[j] = 0;
 
     env->io_access_regions_count--;
     tlb_flush_page(env, address, false);


### PR DESCRIPTION
Fix `tlib_clear_page_io_accessed` wrongly moving `env->io_access_regions` array values.

---

- Call `tlib_set_page_io_accessed` with addresses: `0x400e0e30`, `0x20011944`, `0x200002dc`.
- Call `tlib_clear_page_io_accessed` with `0x200002dc`.

### Before the fix

Array content equaled:

- 0x400e0c00
- 0x400e0c00

### After the fix

Array content equals:

- 0x20011800 (0x20011944)
- 0x400e0c00 (0x400e0e30)