### PR TITLE
Add VBAR (vector base address register) support.

### DIFF
--- a/arch/arm/cpu.h
+++ b/arch/arm/cpu.h
@@ -237,6 +237,7 @@ typedef struct CPUState {
         uint32_t c9_pmxevtyper;  /* perf monitor event type */
         uint32_t c9_pmuserenr;   /* perf monitor user enable */
         uint32_t c9_pminten;     /* perf monitor interrupt enables */
+        uint32_t c12_vbar;       /* vector base address register, security extensions*/
         uint32_t c13_fcse;       /* FCSE PID.  */
         uint32_t c13_context;    /* Context ID.  */
         uint32_t c13_tls1;       /* User RW Thread register.  */
@@ -497,6 +498,7 @@ enum arm_features {
     ARM_FEATURE_OMAPCP,    /* OMAP specific CP15 ops handling.  */
     ARM_FEATURE_THUMB2EE,
     ARM_FEATURE_V7MP,      /* v7 Multiprocessing Extensions */
+    ARM_FEATURE_V7_SEC,    /* v7 Security Extensions */
     ARM_FEATURE_V4T,
     ARM_FEATURE_V5,
     ARM_FEATURE_STRONGARM,


### PR DESCRIPTION
Added VBAR register to the CP15 register set, which is gated by a new ARMv7 Security Extensions CPU feature flag.

The VBAR register is part of the Security Extensions, which it does not appear is supported at all yet. This change DOES NOT add full support for the Security Extensions. It only adds support for the VBAR register.

The project I'm trying to get running on Renode uses this register to relocate the vector table to some arbitrary address. CPU exceptions have been observed to function properly with the changes in this PR.

My main concern with the changes is simply that I added the new feature flags, `ARM_FEATURE_V7_SEC` to all the appropriate CPU models which contain the Security Extensions. I've looked through all the manuals, but may have missed something.

Let me know what you think, and I'll be glad to work to fix any issues.
