### PR TITLE
Add support for mtvt CSR in RISCV32 architecture

### DIFF
--- a/arch/riscv/cpu_registers.c
+++ b/arch/riscv/cpu_registers.c
@@ -127,6 +127,8 @@ uint32_t *get_reg_pointer_32(int reg)
         return &(cpu->mip);
     case SPTBR_32:     // same index as SATP_32
         return (cpu->privilege_architecture >= RISCV_PRIV1_10) ? &(cpu->satp) : &(cpu->sptbr);
+    case MTVT_32:
+        return &(cpu->mtvt);
     case MSTATUS_32:
         return &(cpu->mstatus);
     case MISA_32:

--- a/arch/riscv/cpu_registers.h
+++ b/arch/riscv/cpu_registers.h
@@ -210,6 +210,7 @@ typedef enum {
     SIP_32      = 0x185,
     SATP_32     = 0x1C1,
     SPTBR_32    = 0x1C1,
+    MTVT_32     = 0x307,
     MSTATUS_32  = 0x341,
     MISA_32     = 0x342,
     MEDELEG_32  = 0x343,


### PR DESCRIPTION
1. Add mtvt to support CLIC vectored mode for riscv32.
2. Implement required support in renode-infrastructure.
https://github.com/renode/renode-infrastructure/pull/119
