### PR TITLE
Update ARM code and cpu_exec() function to support ARM sleep-on-exit …

### DIFF
--- a/arch/arm/arch_exports.c
+++ b/arch/arm/arch_exports.c
@@ -192,6 +192,13 @@ EXC_VOID_1(tlib_set_exception_vector_address, uint32_t, address)
 
 #ifdef TARGET_PROTO_ARM_M
 
+void tlib_set_sleep_on_exception_exit(int32_t value)
+{
+    cpu->sleep_on_exception_exit = !!value;
+}
+
+EXC_VOID_1(tlib_set_sleep_on_exception_exit, int32_t, value)
+
 void tlib_set_interrupt_vector_base(uint32_t address)
 {
     cpu->v7m.vecbase = address;

--- a/arch/arm/arch_exports.h
+++ b/arch/arm/arch_exports.h
@@ -22,6 +22,8 @@ uint32_t tlib_get_exception_vector_address(void);
 void tlib_set_exception_vector_address(uint32_t address);
 
 #ifdef TARGET_PROTO_ARM_M
+void tlib_set_sleep_on_exception_exit(int32_t);
+
 void tlib_set_interrupt_vector_base(uint32_t address);
 uint32_t tlib_get_interrupt_vector_base(void);
 void tlib_set_fpu_interrupt_number(int32_t enabled);

--- a/arch/arm/cpu.h
+++ b/arch/arm/cpu.h
@@ -302,6 +302,9 @@ typedef struct CPUState {
         uint32_t rlar[MAX_MPU_REGIONS];
         uint32_t mair[2]; /* The number of these registers is *not* configurable */
     } pmsav8;
+
+    int32_t sleep_on_exception_exit;
+
 #endif
 
     /* Thumb-2 EE state.  */
@@ -726,6 +729,17 @@ static inline void cpu_pc_from_tb(CPUState *env, TranslationBlock *tb)
 }
 
 void do_v7m_exception_exit(CPUState *env);
+
+#ifdef TARGET_PROTO_ARM_M
+static inline bool automatic_sleep_after_interrupt(CPUState *env)
+{
+    if (env->sleep_on_exception_exit) {
+        env->wfi = 1;
+        return true;
+    }
+    return false;
+}
+#endif
 
 static inline void find_pending_irq_if_primask_unset(CPUState *env)
 {

--- a/cpu-exec.c
+++ b/cpu-exec.c
@@ -383,7 +383,10 @@ int cpu_exec(CPUState *env)
                 if (env->regs[15] >= 0xffffff00) {
                     do_v7m_exception_exit(env);
                     next_tb = 0;
-                }
+                    if (automatic_sleep_after_interrupt(env)) {                     
+                        return EXCP_WFI;                        
+                    }                    
+                }                
 #endif
                 if(unlikely(env->mmu_fault))
                 {


### PR DESCRIPTION
On ARM Cortex-M architectures, if the SCR SLEEPONEXIT flag is set, the core will automatically enter sleep after completing all queued exception handlers at the moment it switches back to Thread mode.
We are unsure about the changes to the cpu_exec() function. 
The idea we had is to check after each exception handler if the SLEEPONEXIT flag is set. If it is, we set the env->wfi to true and we return right away from the cpu_exec() function with EXCP_INTERRUPT. This means that we will re-enter cpu_exec() and then in function cpu_has_work(), the evaluation will be done to see if any exceptions are pending or not. If not, then the process to enter sleep will happen, else the env->wfi will be cleared and we will continue with the cpu_exec() processing.
We would like your input to see if this is a good approach or if there would be better ones.