### PR TITLE
arm: Allow UNPREDICTABLE Rm==SP in MOV/ORR T3/T2 encoding

### DIFF
--- a/arch/arm/translate.c
+++ b/arch/arm/translate.c
@@ -11676,7 +11676,14 @@ static int disas_thumb2_insn(CPUState *env, DisasContext *s, uint16_t insn_hw1)
                 uint8_t op0 = (insn >> 15) & 0x1;
                 uint8_t op1 = (insn >> 12) & 0x3;
 
-                if(op0 == 0 && rm != 0xd && rm != 0xf) {
+                if(op0 == 0 && rm != 0xf) {
+                    /*
+                     * ORR (register) T2 / MOV (register) T3.
+                     * Rm==13 (SP) is UNPREDICTABLE per ARMv7-M ARM §A7.7.77/§A7.7.92
+                     * but all Cortex-M silicon executes it as a normal move.
+                     * Allow it here to match hardware behaviour (needed for
+                     * Nordic nRF5 SoftDevice S140 which uses MOV.W R0, SP).
+                     */
                     tmp = load_reg(s, rn);
                     tmp2 = load_reg(s, rm);
                     gen_arm_shift_im(tmp2, shiftop, shift, logic_cc);


### PR DESCRIPTION
The Thumb-2 MOV (register) T3 and ORR (register) T2 decoder rejected Rm==13 (SP) with goto illegal_op, raising UsageFault (UNDEFINSTR). The ARMv7-M ARM marks this as UNPREDICTABLE, not UNDEFINED, and all Cortex-M4 silicon (nRF52840, STM32F4xx) executes it as a simple register move.

This unblocks simulation of the Nordic nRF5 SoftDevice S140 v7.x, which uses MOV.W R0, SP (encoding EA4F 000D) in its SVC dispatcher. 

Tests might be affected due to this. This does not violate spec and allows for booting NRF52840 with soft device running.

[#884 issue](https://github.com/renode/renode/issues/884)