### PR TITLE
arm: Fix VFP feature flags for Cortex-A7 and Cortex-A15

### DIFF
--- a/arch/arm/helper.c
+++ b/arch/arm/helper.c
@@ -163,6 +163,7 @@ static void cpu_reset_model_id(CPUState *env, uint32_t id)
             set_feature(env, ARM_FEATURE_VFP);
             set_feature(env, ARM_FEATURE_VFP3);
             set_feature(env, ARM_FEATURE_VFP4);
+            set_feature(env, ARM_FEATURE_VFP_FP16);
             set_feature(env, ARM_FEATURE_NEON);
             set_feature(env, ARM_FEATURE_GENERIC_TIMER);
             set_feature(env, ARM_FEATURE_THUMB2EE);
@@ -248,6 +249,8 @@ static void cpu_reset_model_id(CPUState *env, uint32_t id)
             set_feature(env, ARM_FEATURE_THUMB2);
             set_feature(env, ARM_FEATURE_V7);
             set_feature(env, ARM_FEATURE_V7SEC);
+            set_feature(env, ARM_FEATURE_VFP);
+            set_feature(env, ARM_FEATURE_VFP3);
             set_feature(env, ARM_FEATURE_VFP4);
             set_feature(env, ARM_FEATURE_VFP_FP16);
             set_feature(env, ARM_FEATURE_NEON);

--- a/arch/arm/helper.c
+++ b/arch/arm/helper.c
@@ -161,6 +161,7 @@ static void cpu_reset_model_id(CPUState *env, uint32_t id)
             set_feature(env, ARM_FEATURE_AUXCR);
             set_feature(env, ARM_FEATURE_THUMB2);
             set_feature(env, ARM_FEATURE_VFP);
+            set_feature(env, ARM_FEATURE_VFP3);
             set_feature(env, ARM_FEATURE_VFP4);
             set_feature(env, ARM_FEATURE_NEON);
             set_feature(env, ARM_FEATURE_GENERIC_TIMER);

--- a/arch/arm/translate.c
+++ b/arch/arm/translate.c
@@ -3439,11 +3439,11 @@ static int disas_vfp_insn(CPUState *env, DisasContext *s, uint32_t insn)
         if((insn & 0x0fe00fff) != 0x0ee00a10) {
 #ifdef TARGET_PROTO_ARM_M
             gen_exception_insn(s, 4, EXCP_NOCP);
+#else
+            gen_exception_insn(s, 4, EXCP_UDEF);
+#endif
             LOCK_TB(s->base.tb);
             return 0;
-#else
-            return 1;
-#endif
         }
         rn = (insn >> 16) & 0xf;
 


### PR DESCRIPTION
## Summary

- Add missing `ARM_FEATURE_VFP3` to Cortex-A7 init (VFP4 requires VFP3)
- Add missing `ARM_FEATURE_VFP` and `ARM_FEATURE_VFP3` to Cortex-A15 init
- Add missing `ARM_FEATURE_VFP_FP16` to Cortex-A7 init
- Generate `EXCP_UDEF` on ARM-A profile when VFP coprocessor access fails feature check, instead of silently returning 1

Without these fixes, Linux kernel VFP init crashes with an undefined instruction exception on `vmrs r2, mvfr1` because the MVFR0/MVFR1 access path in `translate.c` gates on `ARM_FEATURE_VFP3`.

Discovered while booting Linux on an emulated AST2600 (dual Cortex-A7).

## Test plan

- Boot Linux kernel on Cortex-A7 — VFP init completes without crash
- Boot Linux kernel on Cortex-A15 — VFP init completes without crash
- Verify MVFR0/MVFR1 register reads return correct values