### PR TITLE
Fix TLB flush to invalidate all 1K sub-pages within 4K page

### DIFF
--- a/exec.c
+++ b/exec.c
@@ -1451,7 +1451,6 @@ void tlb_flush_masked(CPUState *env, uint32_t mmu_indexes_mask)
 
 void tlb_flush_page_masked(CPUState *env, target_ulong addr, uint32_t mmu_indexes_mask, bool from_generated_code)
 {
-    int i;
     int mmu_idx;
 
     /* Check if we need to flush due to large pages.  */
@@ -1465,15 +1464,21 @@ void tlb_flush_page_masked(CPUState *env, target_ulong addr, uint32_t mmu_indexe
         env->current_tb = NULL;
     }
 
-    addr &= TARGET_PAGE_MASK;
-    i = (addr >> TARGET_PAGE_BITS) & (CPU_TLB_SIZE - 1);
-    for(mmu_idx = 0; mmu_idx < NB_MMU_MODES; mmu_idx += 1) {
-        if(extract32(mmu_indexes_mask, mmu_idx, 1)) {
-            tlb_flush_entry(&env->tlb_table[mmu_idx][i], addr);
+    /* ARM's minimum page size is 4K, but TARGET_PAGE_BITS is 10 (1K).
+       When the guest flushes a 4K page, we must invalidate all 1K
+       sub-pages within that 4K region, otherwise stale TLB entries
+       for sibling sub-pages cause writes to hit wrong physical pages. */
+    target_ulong base_4k = addr & ~(target_ulong)0xFFF;
+    for(target_ulong subpage = base_4k; subpage < base_4k + 0x1000; subpage += TARGET_PAGE_SIZE) {
+        target_ulong sp_addr = subpage & TARGET_PAGE_MASK;
+        int i = (sp_addr >> TARGET_PAGE_BITS) & (CPU_TLB_SIZE - 1);
+        for(mmu_idx = 0; mmu_idx < NB_MMU_MODES; mmu_idx += 1) {
+            if(extract32(mmu_indexes_mask, mmu_idx, 1)) {
+                tlb_flush_entry(&env->tlb_table[mmu_idx][i], sp_addr);
+            }
         }
+        tlb_flush_jmp_cache(env, sp_addr);
     }
-
-    tlb_flush_jmp_cache(env, addr);
 }
 
 void tlb_flush_page(CPUState *env, target_ulong addr, bool from_generated_code)


### PR DESCRIPTION
## Summary

- Fix `tlb_flush_page_masked()` to iterate over all four 1K sub-pages within a 4K aligned region

ARM's minimum hardware page size is 4K, but tlib uses `TARGET_PAGE_BITS=10` (1K sub-pages). When the guest kernel flushes a 4K page via `tlb_flush_page`, only one of the four 1K sub-pages was being invalidated. Stale TLB entries for the other three sub-pages caused writes through fixmap to hit wrong physical pages, corrupting kernel `.text` during dynamic ftrace patching.

Discovered while booting Linux on an emulated AST2600 (Cortex-A7). The kernel would crash with random undefined instruction exceptions in previously-working code, caused by stale TLB entries pointing to wrong physical pages after ftrace modified function prologues via fixmap.

## Test plan

- Boot Linux kernel with `CONFIG_DYNAMIC_FTRACE=y` on Cortex-A7
- Verify no kernel text corruption during ftrace initialization
- Verify TLB flush after fixmap write invalidates all sub-pages