### PR TITLE
Arm7m wfe bug

### DIFF
--- a/arch/arm/helper.c
+++ b/arch/arm/helper.c
@@ -1139,6 +1139,10 @@ void do_v7m_exception_exit(CPUState *env)
     } else {
         env->v7m.handler_mode = true;
     }
+
+    // ARMv7-M ARM B1.4.2: exception return sets the event register,
+    // so a subsequent WFE will fall through immediately.
+    env->sev_pending = 1;
 }
 
 void do_v7m_secure_return(CPUState *env)
@@ -1155,6 +1159,10 @@ void do_v7m_secure_return(CPUState *env)
     env->regs[15] = v7m_pop(env) & ~1;
 
     tlib_printf(LOG_LEVEL_NOISY, "Secure return to 0x%08" PRIx32 ", xpsr: 0x%08" PRIx32, env->regs[15], xpsr_read(env));
+
+    // ARMv7-M ARM B1.4.2: exception return sets the event register,
+    // so a subsequent WFE will fall through immediately.
+    env->sev_pending = 1;
 }
 
 static inline bool lsp_store_helper(CPUState *env, uint32_t *address, uint32_t val)

--- a/arch/arm/helper.c
+++ b/arch/arm/helper.c
@@ -1499,6 +1499,9 @@ static void do_interrupt_v7m(CPUState *env)
         do_interrupt_v7m(env);
     }
 
+    // ARMv7-M ARM B1.4.2: exception entry sets the event register.
+    env->sev_pending = 1;
+
     arm_announce_stack_change();
 }
 #endif

--- a/arch/arm/op_helper.c
+++ b/arch/arm/op_helper.c
@@ -207,6 +207,12 @@ void HELPER(wfi)(void)
 
 void HELPER(wfe)(void)
 {
+    // ARMv7-M ARM B1.4.2: if the event register is set, WFE clears it
+    // and returns immediately without suspending execution.
+    if(env->sev_pending) {
+        env->sev_pending = 0;
+        return;
+    }
     env->exception_index = EXCP_WFI;
     env->wfe = 1;
 }


### PR DESCRIPTION
Missing ARM 7 spec WFE behaviour. This is also not patched in QEMU. Renode attempted a patch it seems for WFE but just missed a small spot. Read more at https://lore.kernel.org/qemu-devel/20260209051931.122531-1-ashish.a6@samsung.com/ and his post https://www.linkedin.com/posts/ashish-anand-570b711aa_sev-and-wfe-instructions-on-arm-activity-7428297595216748544-Z-PU/ 

My related issue and how I found it here --> https://github.com/renode/renode/issues/892 

Tested to unblock soft device on nrf52 for spinning and waiting for events.

* adds one unecessary performance improvement to stop busy wait.