### PR TITLE
cmake: Exclude all Clang variants from -Wno-error=clobbered

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ elseif(CMAKE_BUILD_TYPE STREQUAL "Release")
         add_definitions(-fomit-frame-pointer)
 endif()
 
-if (HOST_ARCH MATCHES "(arm|aarch64)" AND CMAKE_BUILD_TYPE STREQUAL "Release" AND NOT CMAKE_C_COMPILER_ID STREQUAL "AppleClang")
+if (HOST_ARCH MATCHES "(arm|aarch64)" AND CMAKE_BUILD_TYPE STREQUAL "Release" AND NOT CMAKE_C_COMPILER_ID MATCHES "AppleClang|Clang")
     # gcc emits a clobber error for unwind.h DECLARE_ENV_PTR() in release mode on arm targets
     # so demote it to a warning in this case, but not on arm mac clang, because this flag does not exsist
     add_definitions(-Wno-error=clobbered)


### PR DESCRIPTION
The -Wno-error=clobbered flag is GCC-specific, used to demote a clobber error from setjmp/longjmp in DECLARE_ENV_PTR() on ARM release builds. The condition previously only excluded AppleClang, but regular Clang (e.g. on ARM Linux) also does not support this flag, causing build failures. Broaden the check to exclude all Clang-based compilers.