### PR TITLE
riscv: Fix counter access control

### DIFF
--- a/arch/riscv/cpu_bits.h
+++ b/arch/riscv/cpu_bits.h
@@ -429,6 +429,10 @@
 #define SSTATUS_SD  SSTATUS64_SD
 #endif
 
+/* mcountinhibit bits */
+#define MCOUNTINHIBIT_CY 0x00000001
+#define MCOUNTINHIBIT_IR 0x00000004
+
 /* irqs */
 #define IRQ_US (1 << IRQ_U_SOFT)
 #define IRQ_SS (1 << IRQ_S_SOFT)

--- a/arch/riscv/op_helper.c
+++ b/arch/riscv/op_helper.c
@@ -114,7 +114,10 @@ static inline target_ulong get_counter_enabled_mask(CPUState *env)
             case PRV_S:
                 return env->mcounteren;
             case PRV_U:
-                return riscv_has_ext(env, RISCV_FEATURE_RVS) ? env->scounteren : env->mcounteren;
+                if(riscv_has_ext(env, RISCV_FEATURE_RVS)) {
+                    return env->mcounteren & env->scounteren;
+                }
+                return env->mcounteren;
             default:
                 tlib_abortf("Invalid privilege level: %d", env->priv);
                 return 0;
@@ -187,11 +190,17 @@ void helper_raise_illegal_instruction(CPUState *env)
 
 static inline uint64_t get_minstret_current(CPUState *env)
 {
+    if(env->privilege_architecture >= RISCV_PRIV1_11 && (env->mcountinhibit & MCOUNTINHIBIT_IR)) {
+        return env->minstret_snapshot_offset > 0 ? env->minstret_snapshot_offset : 0;
+    }
     return cpu_riscv_read_instret(env) - env->minstret_snapshot + env->minstret_snapshot_offset;
 }
 
 static inline uint64_t get_mcycles_current(CPUState *env)
 {
+    if(env->privilege_architecture >= RISCV_PRIV1_11 && (env->mcountinhibit & MCOUNTINHIBIT_CY)) {
+        return env->mcycle_snapshot_offset > 0 ? env->mcycle_snapshot_offset : 0;
+    }
     uint64_t instructions = cpu_riscv_read_instret(env) - env->mcycle_snapshot + env->mcycle_snapshot_offset;
     return instructions_to_cycles(env, instructions);
 }
@@ -516,7 +525,16 @@ inline void csr_write_helper(CPUState *env, target_ulong val_to_write, target_ul
             if(env->privilege_architecture == RISCV_PRIV1_09) {
                 env->mucounteren = val_to_write;
             } else if(env->privilege_architecture >= RISCV_PRIV1_11) {
+                uint64_t current_mcycle = get_mcycles_current(env);
+                uint64_t current_minstret = get_minstret_current(env);
+                uint64_t current_instret = cpu_riscv_read_instret(env);
+
                 env->mcountinhibit = val_to_write;
+
+                env->mcycle_snapshot_offset = current_mcycle;
+                env->mcycle_snapshot = current_instret;
+                env->minstret_snapshot_offset = current_minstret;
+                env->minstret_snapshot = current_instret;
             }
             break;
         case CSR_MSCOUNTEREN:


### PR DESCRIPTION
This PR fixes RISC-V counter access and inhibition behavior in tlib.

It requires U-mode counter access to be allowed by both mcounteren and scounteren, and fixes mcountinhibit handling so inhibited counters stop advancing immediately.

Related to renode/renode#907
Related to renode/renode#910