### PR TITLE
riscv: Fix privileged trap controls

### DIFF
--- a/arch/riscv/cpu_bits.h
+++ b/arch/riscv/cpu_bits.h
@@ -308,8 +308,8 @@
 #define MSTATUS_MXR  0x00080000
 #define MSTATUS_VM   0x1F000000 /* until: priv-1.9.1 */
 #define MSTATUS_TVM  0x00100000 /* since: priv-1.10 */
-#define MSTATUS_TW   0x20000000 /* since: priv-1.10 */
-#define MSTATUS_TSR  0x40000000 /* since: priv-1.10 */
+#define MSTATUS_TW   0x00200000 /* since: priv-1.10 */
+#define MSTATUS_TSR  0x00400000 /* since: priv-1.10 */
 
 #define MSTATUS_VS_INITIAL 0x00000600
 #define MSTATUS_VS_DIRTY   0x3

--- a/arch/riscv/helper.h
+++ b/arch/riscv/helper.h
@@ -111,6 +111,7 @@ DEF_HELPER_2(sret, tl, env, tl)
 DEF_HELPER_2(mret, tl, env, tl)
 DEF_HELPER_1(wfi, void, env)
 DEF_HELPER_1(fence_i, void, env)
+DEF_HELPER_1(sfence_vma, void, env)
 
 //  Vector helpers require 128-bit ints which aren't supported on 32-bit hosts.
 #if HOST_LONG_BITS != 32

--- a/arch/riscv/op_helper.c
+++ b/arch/riscv/op_helper.c
@@ -412,6 +412,10 @@ inline void csr_write_helper(CPUState *env, target_ulong val_to_write, target_ul
             target_ulong mask = MSTATUS_MIE | MSTATUS_MPIE | MSTATUS_FS | MSTATUS_MPRV | MSTATUS_MPP | MSTATUS_MXR | MSTATUS_VS;
             if(riscv_has_ext(env, RISCV_FEATURE_RVS)) {
                 mask |= MSTATUS_SIE | MSTATUS_SPIE | MSTATUS_SUM | MSTATUS_SPP;
+
+                if(env->privilege_architecture >= RISCV_PRIV1_10) {
+                    mask |= MSTATUS_TVM | MSTATUS_TSR;
+                }
             }
 
             if(env->privilege_architecture < RISCV_PRIV1_10) {
@@ -606,6 +610,9 @@ inline void csr_write_helper(CPUState *env, target_ulong val_to_write, target_ul
             }
             if(env->privilege_architecture >= RISCV_PRIV1_10 && validate_vm(env, get_field(val_to_write, SATP_MODE)) &&
                ((val_to_write ^ env->satp) & (SATP_MODE | SATP_ASID | SATP_PPN))) {
+                if(env->priv == PRV_S && env->mstatus & MSTATUS_TVM) {
+                    helper_raise_illegal_instruction(env);
+                }
                 tlb_flush(env, 1, true);
                 env->satp = val_to_write;
                 if(unlikely(env->guest_profiler_enabled)) {
@@ -971,6 +978,10 @@ static inline target_ulong csr_read_helper(CPUState *env, target_ulong csrno)
             return env->scause;
         case CSR_SATP: /* CSR_SPTBR */
             if(env->privilege_architecture >= RISCV_PRIV1_10) {
+                if(env->priv == PRV_S && env->mstatus & MSTATUS_TVM) {
+                    helper_raise_illegal_instruction(env);
+                    break;
+                }
                 return env->satp;
             } else {
                 return env->sptbr;
@@ -1225,6 +1236,22 @@ target_ulong helper_csrrs(CPUState *env, target_ulong src, target_ulong csr, tar
     return csr_backup;
 }
 
+void helper_sfence_vma(CPUState *env)
+{
+    /* SFENCE.VMA is privileged: U-mode must always trap */
+    if(env->priv < PRV_S) {
+        helper_raise_illegal_instruction(env);
+    }
+
+    /* In S-mode, TVM=1 also traps (priv spec >= 1.10) */
+    if(env->privilege_architecture >= RISCV_PRIV1_10 && env->priv == PRV_S && get_field(env->mstatus, MSTATUS_TVM)) {
+        helper_raise_illegal_instruction(env);
+    }
+
+    /* TODO: handle ASID specific fences */
+    tlb_flush(env, 1, true);
+}
+
 target_ulong helper_csrrc(CPUState *env, target_ulong src, target_ulong csr, target_ulong rs1_pass)
 {
     validate_csr(env, csr, rs1_pass != 0);
@@ -1271,6 +1298,10 @@ target_ulong helper_sret(CPUState *env, target_ulong cpu_pc_deb)
 
     if(env->priv < PRV_S) {
         tlib_printf(LOG_LEVEL_ERROR, "Trying to execute Sret from privilege level %u", env->priv);
+        helper_raise_illegal_instruction(env);
+    }
+
+    if(env->privilege_architecture >= RISCV_PRIV1_10 && env->priv == PRV_S && get_field(env->mstatus, MSTATUS_TSR)) {
         helper_raise_illegal_instruction(env);
     }
 

--- a/arch/riscv/translate.c
+++ b/arch/riscv/translate.c
@@ -3690,8 +3690,7 @@ static void gen_system(DisasContext *dc, uint32_t opc, int rd, int rs1, int rs2,
                 }
                 break;
             case 0x9: /* SFENCE.VMA */
-                /* TODO: handle ASID specific fences */
-                gen_helper_tlb_flush(cpu_env);
+                gen_helper_sfence_vma(cpu_env);
                 break;
             case 0x10: /* HRET */
                 kill_unknown(dc, RISCV_EXCP_ILLEGAL_INST);


### PR DESCRIPTION
This PR fixes RISC-V privileged trap control behavior in tlib.

It allows mstatus.TVM, TW, and TSR to be written when S-mode is supported, fixes their bit definitions, and makes SFENCE.VMA trap when executed from U-mode or when TVM blocks it in S-mode.

Related to renode/renode#908
Related to renode/renode#926