### PR TITLE
riscv: canonicalize malformed half operands for fclass.h

### DIFF
--- a/arch/riscv/translate.c
+++ b/arch/riscv/translate.c
@@ -3662,7 +3662,10 @@ static void gen_fp_arith(DisasContext *dc, uint32_t opc, int rd, int rs1, int rs
             if(rm == 0x0) { /* FMV */
                 gen_helper_fmv_x_h(write_int_rd, cpu_env, cpu_fpr[rs1], rm_reg);
             } else if(rm == 0x1) {
-                gen_helper_fclass_h(write_int_rd, cpu_env, cpu_fpr[rs1]);
+                TCGv_i64 rs1_boxed = tcg_temp_local_new_i64();
+                gen_unbox_float(RISCV_HALF_PRECISION, env, rs1_boxed, cpu_fpr[rs1]);
+                gen_helper_fclass_h(write_int_rd, cpu_env, rs1_boxed);
+                tcg_temp_free_i64(rs1_boxed);
             } else {
                 kill_unknown(dc, RISCV_EXCP_ILLEGAL_INST);
             }


### PR DESCRIPTION
## Summary

On RV64, a non-NaN-boxed half value is a canonical quiet NaN. The `fclass.h` translation path currently passes the raw FPR value to the classification helper, unlike the other half-precision paths. Unbox the operand before classification.

## Validation

- The malformed-operand witness returns the quiet-NaN class bit after the fix; the boxed control is unchanged.
- Renode, QEMU and native RISC-V hardware controls agree.
- The patch is limited to the `fclass.h` translation branch.

Fixes renode/renode#958
