### PR TITLE
riscv: remove obsolete SFENCE.VM branch from gen_system

### DIFF
--- a/arch/riscv/translate.c
+++ b/arch/riscv/translate.c
@@ -3718,9 +3718,6 @@ static void gen_system(DisasContext *dc, uint32_t opc, int rd, int rs1, int rs2,
                         gen_exit_tb_no_chaining(dc->base.tb);
                         dc->base.is_jmp = DISAS_BRANCH;
                         break;
-                    case 0x4: /* SFENCE.VM */
-                        gen_helper_tlb_flush(cpu_env);
-                        break;
                     case 0x5: /* WFI */
                         tcg_gen_movi_tl(cpu_pc, dc->npc);
                         gen_helper_wfi(cpu_env);


### PR DESCRIPTION
## Summary

`gen_system()` still dispatches `funct7=0x8`/`rs2=0x4` to the TLB flush helper, implementing the `SFENCE.VM` instruction that was removed from the RISC-V privileged architecture in version 1.10. With the default `Priv1_11` configuration of `RiscV64`, the encoding `0x10400073` is retired as a legal instruction instead of raising an illegal-instruction exception.

Delete the obsolete branch so the encoding falls into the existing default case and raises `RISCV_EXCP_ILLEGAL_INST`.

## Validation

- The firmware witness traps with `mcause=2, mepc=0x1018` after the fix.
- QEMU and native RISC-V hardware reject the encoding with SIGILL.
- The legal control `SFENCE.VMA x0,x0` is unaffected.
- The patch is deliberately limited to the `funct7=0x8`/`rs2=0x4` branch and does not touch SRET/WFI or the CSR paths.

Fixes renode/renode#962
