### PR TITLE
xtensa: fix OOB TLB entry access

### DIFF
--- a/arch/xtensa/mmu_helper.c
+++ b/arch/xtensa/mmu_helper.c
@@ -201,20 +201,29 @@ static void split_tlb_entry_spec_way(const CPUState *env, uint32_t v, bool dtlb,
  * Split TLB address into TLB way, entry index and VPN (with index).
  * See ISA, 4.6.5.5 - 4.6.5.8 for the TLB addressing format
  */
-static void split_tlb_entry_spec(CPUState *env, uint32_t v, bool dtlb, uint32_t *vpn, uint32_t *wi, uint32_t *ei)
+static bool split_tlb_entry_spec(CPUState *env, uint32_t v, bool dtlb, uint32_t *vpn, uint32_t *wi, uint32_t *ei)
 {
     if(xtensa_option_enabled(env->config, XTENSA_OPTION_MMU)) {
         *wi = v & (dtlb ? 0xf : 0x7);
-        split_tlb_entry_spec_way(env, v, dtlb, vpn, *wi, ei);
+        if(*wi < (dtlb ? env->config->dtlb.nways : env->config->itlb.nways)) {
+            split_tlb_entry_spec_way(env, v, dtlb, vpn, *wi, ei);
+            return true;
+        } else {
+            return false;
+        }
     } else {
         *vpn = v & REGION_PAGE_MASK;
         *wi = 0;
         *ei = (v >> 29) & 0x7;
+        return true;
     }
 }
 
 static xtensa_tlb_entry *xtensa_tlb_get_entry(CPUState *env, bool dtlb, unsigned wi, unsigned ei)
 {
+    const xtensa_tlb *tlb = dtlb ? &env->config->dtlb : &env->config->itlb;
+
+    tlib_assert(wi < tlb->nways && ei < tlb->way_size[wi]);
     return dtlb ? env->dtlb[wi] + ei : env->itlb[wi] + ei;
 }
 
@@ -224,11 +233,14 @@ static xtensa_tlb_entry *get_tlb_entry(CPUState *env, uint32_t v, bool dtlb, uin
     uint32_t wi;
     uint32_t ei;
 
-    split_tlb_entry_spec(env, v, dtlb, &vpn, &wi, &ei);
-    if(pwi) {
-        *pwi = wi;
+    if(split_tlb_entry_spec(env, v, dtlb, &vpn, &wi, &ei)) {
+        if(pwi) {
+            *pwi = wi;
+        }
+        return xtensa_tlb_get_entry(env, dtlb, wi, ei);
+    } else {
+        return NULL;
     }
-    return xtensa_tlb_get_entry(env, dtlb, wi, ei);
 }
 
 static void xtensa_tlb_set_entry_mmu(const CPUState *env, xtensa_tlb_entry *entry, bool dtlb, unsigned wi, unsigned ei,
@@ -416,7 +428,12 @@ uint32_t HELPER(rtlb0)(CPUState *env, uint32_t v, uint32_t dtlb)
     if(xtensa_option_enabled(env->config, XTENSA_OPTION_MMU)) {
         uint32_t wi;
         const xtensa_tlb_entry *entry = get_tlb_entry(env, v, dtlb, &wi);
-        return (entry->vaddr & get_vpn_mask(env, dtlb, wi)) | entry->asid;
+
+        if(entry) {
+            return (entry->vaddr & get_vpn_mask(env, dtlb, wi)) | entry->asid;
+        } else {
+            return 0;
+        }
     } else {
         return v & REGION_PAGE_MASK;
     }
@@ -425,7 +442,12 @@ uint32_t HELPER(rtlb0)(CPUState *env, uint32_t v, uint32_t dtlb)
 uint32_t HELPER(rtlb1)(CPUState *env, uint32_t v, uint32_t dtlb)
 {
     const xtensa_tlb_entry *entry = get_tlb_entry(env, v, dtlb, NULL);
-    return entry->paddr | entry->attr;
+
+    if(entry) {
+        return entry->paddr | entry->attr;
+    } else {
+        return 0;
+    }
 }
 
 void HELPER(itlb)(CPUState *env, uint32_t v, uint32_t dtlb)
@@ -433,7 +455,7 @@ void HELPER(itlb)(CPUState *env, uint32_t v, uint32_t dtlb)
     if(xtensa_option_enabled(env->config, XTENSA_OPTION_MMU)) {
         uint32_t wi;
         xtensa_tlb_entry *entry = get_tlb_entry(env, v, dtlb, &wi);
-        if(entry->variable && entry->asid) {
+        if(entry && entry->variable && entry->asid) {
             tlb_flush_page(env, entry->vaddr, true);
             entry->asid = 0;
         }
@@ -471,8 +493,9 @@ void HELPER(wtlb)(CPUState *env, uint32_t p, uint32_t v, uint32_t dtlb)
     uint32_t vpn;
     uint32_t wi;
     uint32_t ei;
-    split_tlb_entry_spec(env, v, dtlb, &vpn, &wi, &ei);
-    xtensa_tlb_set_entry(env, dtlb, wi, ei, vpn, p);
+    if(split_tlb_entry_spec(env, v, dtlb, &vpn, &wi, &ei)) {
+        xtensa_tlb_set_entry(env, dtlb, wi, ei, vpn, p);
+    }
 }
 
 /*!


### PR DESCRIPTION
Backport of QEMU commit [`604927e357c2`](https://github.com/qemu/qemu/commit/604927e357c2) ("target/xtensa: fix OOB TLB entry access", 2023-12-15), which tlib's xtensa port predates.

## The problem

`r[id]tlb[01]` and `[iw][id]tlb` take the TLB way index from a guest register. `split_tlb_entry_spec()` masks it with `0x7` for the ITLB and `0xf` for the DTLB:

```c
*wi = v & (dtlb ? 0xf : 0x7);
```

but the backing host arrays in `arch/xtensa/cpu.h` are

```c
xtensa_tlb_entry itlb[7][MAX_TLB_WAY_SIZE];
xtensa_tlb_entry dtlb[10][MAX_TLB_WAY_SIZE];
```

so way index 7 is out of bounds for the ITLB and 10..15 are out of bounds for the DTLB. `xtensa_tlb_get_entry()` indexes them without any check, and `get_tlb_entry()` cannot fail, so `rdtlb0` / `rdtlb1` / `wdtlb` / `witlb` / `idtlb` / `iitlb` let guest code read and write host memory past those arrays.

## The fix

Same shape as upstream:

- `split_tlb_entry_spec()` returns whether the requested way is valid;
- `get_tlb_entry()` returns `NULL` for an invalid way;
- the `rtlb0` / `rtlb1` / `itlb` helpers check for `NULL` and return 0 or do nothing;
- `wtlb` skips the write for an invalid way;
- `xtensa_tlb_get_entry()` asserts that the way and entry indices are in range.

## Affected cores

Only cores with `XCHAL_HAVE_PTP_MMU`, i.e. those enabling `XTENSA_OPTION_MMU`: `dc233c`, `de233_fpu`, `test_mmuhifi_c3`. Cores using region protection instead — including `esp32` and `esp32s3` — take the `else` branch of `split_tlb_entry_spec()`, where the way index is hardcoded to 0.

## One deliberate deviation from upstream

The new bounds check in `xtensa_tlb_get_entry()` uses `tlib_assert()` rather than `assert()`. `assert()` is compiled out in the Release build, which both defeats the check where it matters and leaves the `tlb` local unused — the first build of this patch emitted `-Wunused-variable`. `tlib_assert()` is always active and reports through `tlib_abortf()`, consistent with its use elsewhere in tlib. Happy to switch it back if you'd rather stay byte-for-byte with upstream.

## Testing

- Rebuilt `translate-xtensa-le.so` for `TARGET_ARCH=xtensa`, `CMAKE_BUILD_TYPE=Release`: compiles without warnings.
- Booted a real ESP-IDF image on an `esp32s3` core before and after: behaviour unchanged, and the new assertion does not fire. That path reaches `xtensa_tlb_get_entry()` through `get_physical_addr_region()` with `wi = 0` and `ei` masked to 0..7, against a region-protection TLB configured as `nways = 1, way_size = {8}` — in range by construction.
- I have no MMU-core setup to exercise the faulty path itself, so the out-of-bounds access is established by code reading rather than reproduced.
